### PR TITLE
Use the subject color in the calendar.

### DIFF
--- a/lib/actions/settings_actions.dart
+++ b/lib/actions/settings_actions.dart
@@ -44,5 +44,6 @@ abstract class SettingsActions extends ReduxActions {
   abstract final ActionDispatcher<bool> showCalendarSubjectNicksBar;
   abstract final ActionDispatcher<bool> drawerExpandedChange;
   abstract final ActionDispatcher<bool> dashboardColorBorders;
+  abstract final ActionDispatcher<bool> calendarColorBackground;
   abstract final ActionDispatcher<bool> dashboardColorTestsInRed;
 }

--- a/lib/app_state.dart
+++ b/lib/app_state.dart
@@ -300,6 +300,8 @@ abstract class SettingsState
 
   // whether to color the borders of items in the color specified by subjectThemes
   bool get dashboardColorBorders;
+  // whether to color the background of widgets in the calendar in the color specified by subjectThemes
+  bool get calendarColorBackground;
   bool get dashboardColorTestsInRed;
   BuiltMap<String, SubjectTheme> get subjectThemes;
   BuiltList<String> get ignoreForGradesAverage;
@@ -343,6 +345,7 @@ abstract class SettingsState
       ..drawerFullyExpanded = true
       ..ignoreForGradesAverage = ListBuilder()
       ..dashboardColorBorders = false
+      ..calendarColorBackground = false
       ..dashboardColorTestsInRed = true
       ..scrollToGrades = false
       ..scrollToSubjectNicks = false;

--- a/lib/container/calendar_week_container.dart
+++ b/lib/container/calendar_week_container.dart
@@ -61,6 +61,8 @@ abstract class CalendarWeekViewModel
   BuiltMap<String, String> get subjectNicks;
   bool get noInternet;
   CalendarSelection? get selection;
+  bool get colorBackground;
+  BuiltMap<String, SubjectTheme> get subjectThemes;
 
   factory CalendarWeekViewModel(
           [void Function(CalendarWeekViewModelBuilder)? updates]) =
@@ -82,7 +84,9 @@ abstract class CalendarWeekViewModel
               ),
         )
         ..noInternet = state.noInternet
-        ..selection = state.calendarState.selection?.toBuilder(),
+        ..selection = state.calendarState.selection?.toBuilder()
+        ..colorBackground = state.settingsState.calendarColorBackground
+        ..subjectThemes = state.settingsState.subjectThemes.toBuilder(),
     );
   }
 }

--- a/lib/container/settings_page.dart
+++ b/lib/container/settings_page.dart
@@ -64,6 +64,7 @@ class SettingsPageContainer extends StatelessWidget {
               actions.settingsActions.ignoreSubjectsForAverage(BuiltList(list)),
           onSetDashboardColorBorders:
               actions.settingsActions.dashboardColorBorders.call,
+          onSetCalenderColorBackground: actions.settingsActions.calendarColorBackground.call,
           onSetDashboardColorTestsInRed:
               actions.settingsActions.dashboardColorTestsInRed.call,
           onSetSubjectTheme: actions.settingsActions.setSubjectTheme.call,
@@ -92,6 +93,7 @@ class SettingsViewModel {
   final bool showSubjectNicks;
   final bool showGradesSettings;
   final bool dashboardColorBorders;
+  final bool calendarColorBackground;
   final bool dashboardColorTestsInRed;
   final bool demoMode;
   final List<String> allSubjects;
@@ -113,6 +115,7 @@ class SettingsViewModel {
         dashboardDeduplicateEntries =
             state.settingsState.dashboardDeduplicateEntries,
         dashboardColorBorders = state.settingsState.dashboardColorBorders,
+        calendarColorBackground = state.settingsState.calendarColorBackground,
         dashboardColorTestsInRed = state.settingsState.dashboardColorTestsInRed,
         allSubjects = state.extractAllSubjects(),
         ignoreForGradesAverage =

--- a/lib/reducer/settings.dart
+++ b/lib/reducer/settings.dart
@@ -52,6 +52,7 @@ final settingsReducerBuilder = NestedReducerBuilder<AppState, AppStateBuilder,
   ..add(SettingsActionsNames.setSubjectTheme, _setSubjectTheme)
   ..add(SettingsActionsNames.drawerExpandedChange, _drawerFullyExpanded)
   ..add(SettingsActionsNames.dashboardColorBorders, _dashboardColorBorders)
+  ..add(SettingsActionsNames.calendarColorBackground, _calendarColorBackground)
   ..add(
       SettingsActionsNames.dashboardColorTestsInRed, _dashboardColorTestsInRed);
 
@@ -156,6 +157,11 @@ void _drawerFullyExpanded(
 void _dashboardColorBorders(
     SettingsState state, Action<bool> action, SettingsStateBuilder builder) {
   builder.dashboardColorBorders = action.payload;
+}
+
+void _calendarColorBackground(
+    SettingsState state, Action<bool> action, SettingsStateBuilder builder) {
+  builder.calendarColorBackground = action.payload;
 }
 
 void _dashboardColorTestsInRed(

--- a/lib/ui/calendar_week.dart
+++ b/lib/ui/calendar_week.dart
@@ -65,6 +65,8 @@ class CalendarWeek extends StatelessWidget {
                               selectedHour: vm.selection?.date == d.date
                                   ? vm.selection?.hour
                                   : null,
+                              colorBackground: vm.colorBackground,
+                              subjectThemes: vm.subjectThemes,
                             ),
                           ),
                         )
@@ -83,12 +85,17 @@ class _HoursChunk extends StatelessWidget {
   final CalendarDay day;
   final int? selectedHour;
   final bool isSelected;
+  final bool colorBackground;
+  final BuiltMap<String, SubjectTheme> subjectThemes;
+
   const _HoursChunk({
     required this.subjectNicks,
     required this.hours,
     required this.day,
     required this.selectedHour,
     required this.isSelected,
+    required this.colorBackground,
+    required this.subjectThemes,
   });
 
   @override
@@ -125,6 +132,17 @@ class _HoursChunk extends StatelessWidget {
                       subjectNicks: subjectNicks,
                       day: day,
                       isSelected: selectedHour == hours[n ~/ 2].fromHour,
+                      backgroundColor: colorBackground
+                          ? Color(subjectThemes[hours[n ~/ 2].subject]!.color)
+                              .withOpacity(0.25)
+                          : const Color(0).withOpacity(0),
+                      selectedBackgroundColor: colorBackground
+                          ? Color(subjectThemes[hours[n ~/ 2].subject]!.color)
+                              .withOpacity(0.5)
+                          : Theme.of(context)
+                              .colorScheme
+                              .secondary
+                              .withAlpha(35),
                     )
                   : const Divider(
                       height: 0,
@@ -143,6 +161,8 @@ class CalendarDayWidget extends StatelessWidget {
   final BuiltMap<String, String> subjectNicks;
   final bool isSelected;
   final int? selectedHour;
+  final bool colorBackground;
+  final BuiltMap<String, SubjectTheme> subjectThemes;
 
   const CalendarDayWidget({
     super.key,
@@ -151,6 +171,8 @@ class CalendarDayWidget extends StatelessWidget {
     required this.subjectNicks,
     required this.isSelected,
     required this.selectedHour,
+    required this.colorBackground,
+    required this.subjectThemes
   });
   @override
   Widget build(BuildContext context) {
@@ -190,6 +212,8 @@ class CalendarDayWidget extends StatelessWidget {
                 day: calendarDay,
                 selectedHour: selectedHour,
                 isSelected: isSelected,
+                colorBackground: colorBackground,
+                subjectThemes: subjectThemes,
               ),
             )
           ],
@@ -230,12 +254,17 @@ class HourWidget extends StatelessWidget {
   final CalendarDay day;
   final BuiltMap<String, String> subjectNicks;
   final bool isSelected;
+  final Color backgroundColor;
+  final Color selectedBackgroundColor;
+
   const HourWidget({
     super.key,
     required this.hour,
     required this.subjectNicks,
     required this.day,
     required this.isSelected,
+    required this.backgroundColor,
+    required this.selectedBackgroundColor,
   });
   @override
   Widget build(BuildContext context) {
@@ -258,8 +287,8 @@ class HourWidget extends StatelessWidget {
                     )
                   : null,
               color: isSelected
-                  ? Theme.of(context).colorScheme.secondary.withAlpha(35)
-                  : null,
+                  ? selectedBackgroundColor
+                  : backgroundColor,
             ),
             child: Center(
               child: Column(

--- a/lib/ui/settings_page_widget.dart
+++ b/lib/ui/settings_page_widget.dart
@@ -53,6 +53,7 @@ class SettingsPageWidget extends StatefulWidget {
   final OnSettingChanged<bool> onSetFollowDeviceDarkMode;
   final OnSettingChanged<bool> onSetPlatformOverride;
   final OnSettingChanged<bool> onSetDashboardColorBorders;
+  final OnSettingChanged<bool> onSetCalenderColorBackground;
   final OnSettingChanged<bool> onSetDashboardColorTestsInRed;
   final OnSettingChanged<MapEntry<String, SubjectTheme>> onSetSubjectTheme;
   final OnSettingChanged<Map<String, String>> onSetSubjectNicks;
@@ -79,6 +80,7 @@ class SettingsPageWidget extends StatefulWidget {
     required this.onShowProfile,
     required this.onSetIgnoreForGradesAverage,
     required this.onSetDashboardColorBorders,
+    required this.onSetCalenderColorBackground,
     required this.onSetSubjectTheme,
     required this.onSetDashboardColorTestsInRed,
   });
@@ -285,6 +287,13 @@ class _SettingsPageWidgetState extends State<SettingsPageWidget> {
             ),
             value: widget.vm.dashboardColorBorders,
             onChanged: widget.onSetDashboardColorBorders,
+          ),
+          SwitchListTile.adaptive(
+            title: const Text(
+              "Stunden im Kalender mit diesen Farben färben",
+            ),
+            value: widget.vm.calendarColorBackground,
+            onChanged: widget.onSetCalenderColorBackground,
           ),
           SwitchListTile.adaptive(
             title: const Text(


### PR DESCRIPTION
Erst mal möchte ich mich für deine App bedanken, ich verwende sie täglich auf dem Handy und sie ist wirklich sehr praktisch. Danke!

Diese PR macht den Kalender etwas mehr farbenfroher. Die Fächer haben jetzt ihre Farbe (dieselbe Farbe, welche auch z. B. bei dem Graphen verwendet wird) als Hintergrund. 

Ich weiß nicht, wie dieses Feature in deine Vision der App passt, deswegen habe ich einen Eintrag in den Einstellungen erstellt, welche es an/aus schaltet, standardmäßig ist es aus.

Ich hatte bisher keine Erfahrung mit Dart daher, wenn es Bedenken an meiner Implementation gibt, nur zu.

Liebe Grüße aus der TFO in Meran 👋

![image](https://github.com/miDeb/digitales_register/assets/110036308/f3e9f1f3-1c3d-4b30-9199-fffb266796e4)
![image](https://github.com/miDeb/digitales_register/assets/110036308/7bf83850-c294-4766-bdb8-b286e9d58129)
