### PR TITLE
Add "Lernkontrolle" to estimateShouldWarn function in data.dart

### DIFF
--- a/lib/data.dart
+++ b/lib/data.dart
@@ -28,6 +28,7 @@ part 'data.g.dart';
 
 bool estimateShouldWarn(String name) {
   return name == "Schularbeit" ||
+      name == "Lernkontrolle" ||
       name == "Testarbeit" ||
       name.contains("Prüfung");
 }


### PR DESCRIPTION
**I hope this doesn't break something.**


Actually, how does the official register know whether it's an entry with a warning?
Here's the data for the entry with the title "Lernkontrolle" which is not being recognised correctly by the app:
```
            {
                "id": 418,
                "category": 418,
                "type": "gradeGroup",
                "title": "Lernkontrolle",
                "subtitle": "LZK \"Logisches und stichhaltiges Argumentieren\"",
                "label": "Deut",
                "warning": false,
                "0": true,
                "checkable": true,
                "checked": false,
                "online": 0,
                "submission": null,
                "deadline": "2023-09-26 08:30:00",
                "deadlineFormatted": "Dienstag, 26.09.2023, 08:30",
                "deadlineStart": null,
                "deadlineStartFormatted": "Donnerstag, 01.01.1970, 01:00",
                "submissionAllowed": 0,
                "submissionResigned": false,
                "submissionIsNowInOvertime": false,
                "homework": 0,
                "done": null,
                "gradeGroupSubmissions": null
            }
```

Could the `"homework": 0` value be used to estimate a warning? For homework it is really 1. But I'm pretty sure there's another case where it is 0 and also not an exam. Not sure tho.

